### PR TITLE
Update ldfparser.py

### DIFF
--- a/ldfparser.py
+++ b/ldfparser.py
@@ -164,7 +164,7 @@ class LDFParser:
 
     def _parse_signal(self, signal):
         """parse the signals into name, size, init value, publisher and subscribers if supplied"""
-        data = signal.split(':')
+        data = signal.replace('{','').replace('}','').split(':')
         name = data[0]
         data = data[1].split(',')
         raw = {}


### PR DESCRIPTION
filtering signal name for { & }, this parser crashes, when the name includes following{32,0,0} and split is done on , and its results in not int ex: {32 value when passed through int()